### PR TITLE
Add input objects to manage validation before creating entity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,4 +10,5 @@ deploy:
 	php bin/console server:start
 
 integration:
+	php bin/console doctrine:fixtures:load -q
 	bin/behat --suite=graphql tests/features

--- a/README.md
+++ b/README.md
@@ -132,3 +132,16 @@ If you corrupt data you can drop database and reload fixtures using this command
 ```
 $ make install
 ```
+
+### Tests
+
+There is some functional tests, read it to see some useful examples.  
+It basically launch [queries](tests/features/bootstrap/resources/graphql_query/) and check response.  
+
+To launch them use : 
+
+```
+$ make integration
+```
+
+:warning: It will truncate database and dump default fixtures.

--- a/config/graphql/types/Mutation.yaml
+++ b/config/graphql/types/Mutation.yaml
@@ -4,13 +4,13 @@ Mutation:
         fields:
             CreateCar:
                 type: Car!
-                resolve: "@=mutation('create_car', [idFromGlobalId(args['input']['id']), args['input']['manufacturer'], args['input']['model'], args['input']['seats_number']])"
+                resolve: "@=mutation('create_car', [args])"
                 args:
                     input:
                         type: CarInput!
             UpdateCar:
                 type: Car!
-                resolve: "@=mutation('update_car', [idFromGlobalId(args['input']['id']), args['input']['manufacturer'], args['input']['model'], args['input']['seats_number']])"
+                resolve: "@=mutation('update_car', [args])"
                 args:
                     input:
                         type: CarInput!
@@ -22,13 +22,13 @@ Mutation:
                         type: IdInput!
             CreateTruck:
                 type: Truck!
-                resolve: "@=mutation('create_truck', [idFromGlobalId(args['input']['id']), args['input']['manufacturer'], args['input']['model'], args['input']['maximum_load']])"
+                resolve: "@=mutation('create_truck', [args])"
                 args:
                     input:
                         type: TruckInput!
             UpdateTruck:
                 type: Truck!
-                resolve: "@=mutation('update_truck', [idFromGlobalId(args['input']['id']), args['input']['manufacturer'], args['input']['model'], args['input']['maximum_load']])"
+                resolve: "@=mutation('update_truck', [args])"
                 args:
                     input:
                         type: TruckInput!

--- a/config/validator/validation.yaml
+++ b/config/validator/validation.yaml
@@ -1,20 +1,52 @@
 App\Vehicle\Domain\VehicleAbstract:
     properties:
+        id:
+            - NotBlank:
+                groups: [create, update]
+            - Type:
+                type: string
+                groups: [create, update]
         manufacturer:
-            - NotBlank: ~
+            - NotBlank:
+                groups: [create, update]
             - Length:
                 min: 2
+                groups: [create, update]
         model:
-            - NotBlank: ~
+            - NotBlank:
+                groups: [create, update]
             - Length:
                 min: 2
+                groups: [create, update]
 
-App\Vehicle\Domain\Car:
+App\Vehicle\Domain\Input\CarInput:
     properties:
+        id:
+          - App\Common\Infra\Validator\IdDoesNotExistConstraint:
+              fqcn: App\Vehicle\Domain\Car
+              groups: [create]
+          - App\Common\Infra\Validator\IdExistConstraint:
+              fqcn: App\Vehicle\Domain\Car
+              groups: [update]
         seatsNumber:
-            - NotBlank: ~
+            - NotBlank:
+                groups: [create, update]
+            - Type:
+                type: integer
+                groups: [create, update]
 
-App\Vehicle\Domain\Truck:
+App\Vehicle\Domain\Input\TruckInput:
     properties:
+        id:
+            - App\Common\Infra\Validator\IdDoesNotExistConstraint:
+                fqcn: App\Vehicle\Domain\Truck
+                groups: [create]
+            - App\Common\Infra\Validator\IdExistConstraint:
+                fqcn: App\Vehicle\Domain\Truck
+                groups: [update]
         maximumLoad:
-            - NotBlank: ~
+            - NotBlank:
+                groups: [create, update]
+            - Type:
+                type: integer
+                groups: [create, update]

--- a/src/Common/App/Formatter/ValidationExceptionFormatter.php
+++ b/src/Common/App/Formatter/ValidationExceptionFormatter.php
@@ -20,7 +20,7 @@ class ValidationExceptionFormatter
             $violations = $error->getViolations();
             foreach($violations as $violation) {
                 $errors[] = [
-                    'field' => $violation->getPropertyPath(),
+                    'name' => $violation->getPropertyPath(),
                     'message' => $violation->getMessage(),
                 ];
             }

--- a/src/Common/App/Transformer/AppGlobalId.php
+++ b/src/Common/App/Transformer/AppGlobalId.php
@@ -20,4 +20,19 @@ class AppGlobalId extends GlobalId
 
         return $decodedGlobalId['id'];
     }
+
+    /**
+     * @param $globalId
+     * @return string|null
+     */
+    public static function getTypeFromGlobalId(?string $globalId): ?string
+    {
+        $decodedGlobalId = parent::fromGlobalId($globalId);
+
+        if (!$decodedGlobalId['type']) {
+            return null;
+        }
+
+        return $decodedGlobalId['type'];
+    }
 }

--- a/src/Common/Infra/Validator/IdDoesNotExistConstraint.php
+++ b/src/Common/Infra/Validator/IdDoesNotExistConstraint.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Common\Infra\Validator;
+
+use Symfony\Component\Validator\Constraint;
+
+class IdDoesNotExistConstraint extends Constraint
+{
+    /**
+     * @var string
+     */
+    public $message = '%className% [%id%] already exist';
+
+    /**
+     * @var string
+     */
+    public $fqcn;
+
+    /**
+     * @return string
+     */
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFqcn(): string
+    {
+        return $this->fqcn;
+    }
+}

--- a/src/Common/Infra/Validator/IdDoesNotExistConstraintValidator.php
+++ b/src/Common/Infra/Validator/IdDoesNotExistConstraintValidator.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Common\Infra\Validator;
+
+use App\Common\App\Transformer\AppGlobalId;
+use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\ORM\EntityRepository;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+class IdDoesNotExistConstraintValidator extends ConstraintValidator
+{
+    /**
+     * @var ObjectManager
+     */
+    private $em;
+
+    /**
+     * @param ObjectManager $em
+     */
+    public function __construct(ObjectManager $em)
+    {
+        $this->em = $em;
+    }
+
+    /**
+     * @param mixed $identifier
+     * @param Constraint $constraint
+     * @throws \ReflectionException
+     */
+    public function validate($identifier, Constraint $constraint)
+    {
+        if ($identifier === null || !is_string($identifier)) {
+            return;
+        }
+
+        if (!class_exists($constraint->getFqcn())) {
+            throw new \InvalidArgumentException(sprintf(
+                'Constraint FQCN [%s] does not exist',
+                $constraint->getFqcn()
+            ));
+        }
+
+        if ($this->getRepository($constraint->getFqcn())->find($identifier) !== null) {
+            $this->context->buildViolation($constraint->getMessage())
+                ->setParameters([
+                    '%className%' => (new \ReflectionClass($constraint->getFqcn()))->getShortName(),
+                    '%id%' => AppGlobalId::toGlobalId((new \ReflectionClass($constraint->getFqcn()))->getShortName(), $identifier),
+                ])
+                ->addViolation();
+        }
+    }
+
+    /**
+     * @param string $fqcn
+     * @return EntityRepository
+     */
+    protected function getRepository(string $fqcn): EntityRepository
+    {
+        return $this->em->getRepository($fqcn);
+    }
+}

--- a/src/Common/Infra/Validator/IdExistConstraint.php
+++ b/src/Common/Infra/Validator/IdExistConstraint.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Common\Infra\Validator;
+
+use Symfony\Component\Validator\Constraint;
+
+class IdExistConstraint extends Constraint
+{
+    /**
+     * @var string
+     */
+    public $message = '%className% [%id%] not found';
+
+    /**
+     * @var string
+     */
+    public $fqcn;
+
+    /**
+     * @return string
+     */
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFqcn(): string
+    {
+        return $this->fqcn;
+    }
+}

--- a/src/Common/Infra/Validator/IdExistConstraintValidator.php
+++ b/src/Common/Infra/Validator/IdExistConstraintValidator.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Common\Infra\Validator;
+
+use App\Common\App\Transformer\AppGlobalId;
+use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\ORM\EntityRepository;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+class IdExistConstraintValidator extends ConstraintValidator
+{
+    /**
+     * @var ObjectManager
+     */
+    private $em;
+
+    /**
+     * @param ObjectManager $em
+     */
+    public function __construct(ObjectManager $em)
+    {
+        $this->em = $em;
+    }
+
+    /**
+     * @param mixed $identifier
+     * @param Constraint $constraint
+     * @throws \ReflectionException
+     */
+    public function validate($identifier, Constraint $constraint)
+    {
+        if ($identifier === null || !is_string($identifier)) {
+            return;
+        }
+
+        if (!class_exists($constraint->getFqcn())) {
+            throw new \InvalidArgumentException(sprintf(
+                'Constraint FQCN [%s] does not exist',
+                $constraint->getFqcn()
+            ));
+        }
+
+        if ($this->getRepository($constraint->getFqcn())->find($identifier) === null) {
+            $this->context->buildViolation($constraint->getMessage())
+                ->setParameters([
+                    '%className%' => (new \ReflectionClass($constraint->getFqcn()))->getShortName(),
+                    '%id%' => AppGlobalId::toGlobalId((new \ReflectionClass($constraint->getFqcn()))->getShortName(), $identifier),
+                ])
+                ->addViolation();
+        }
+    }
+
+    /**
+     * @param string $fqcn
+     * @return EntityRepository
+     */
+    protected function getRepository(string $fqcn): EntityRepository
+    {
+        return $this->em->getRepository($fqcn);
+    }
+}

--- a/src/Vehicle/App/Factory/VehicleFactory.php
+++ b/src/Vehicle/App/Factory/VehicleFactory.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Vehicle\App\Factory;
+
+use App\Common\App\Transformer\AppGlobalId;
+use App\Vehicle\Domain\Car;
+use App\Vehicle\Domain\Input\CarInput;
+use App\Vehicle\Domain\Input\TruckInput;
+use App\Vehicle\Domain\Truck;
+use Overblog\GraphQLBundle\Definition\Argument;
+
+class VehicleFactory
+{
+    /**
+     * @param Argument $argument
+     * @return CarInput
+     */
+    public static function createCarInput(Argument $argument): CarInput
+    {
+        $input = $argument->offsetGet('input');
+
+        return new CarInput(
+            AppGlobalId::getIdFromGlobalId($input['id']),
+            $input['manufacturer'],
+            $input['model'],
+            $input['seats_number']
+        );
+    }
+
+    /**
+     * @param CarInput $input
+     * @return Car
+     */
+    public static function createCar(CarInput $input): Car
+    {
+        return new Car(
+            $input->getId(),
+            $input->getManufacturer(),
+            $input->getModel(),
+            $input->getSeatsNumber()
+        );
+    }
+
+    /**
+     * @param Argument $argument
+     * @return TruckInput
+     */
+    public static function createTruckInput(Argument $argument): TruckInput
+    {
+        $input = $argument->offsetGet('input');
+
+        return new TruckInput(
+            AppGlobalId::getIdFromGlobalId($input['id']),
+            $input['manufacturer'],
+            $input['model'],
+            $input['maximum_load']
+        );
+    }
+
+    /**
+     * @param TruckInput $input
+     * @return Truck
+     */
+    public static function createTruck(TruckInput $input): Truck
+    {
+        return new Truck(
+            $input->getId(),
+            $input->getManufacturer(),
+            $input->getModel(),
+            $input->getMaximumLoad()
+        );
+    }
+}

--- a/src/Vehicle/App/Mutation/VehicleMutation.php
+++ b/src/Vehicle/App/Mutation/VehicleMutation.php
@@ -27,14 +27,17 @@ class VehicleMutation implements MutationInterface, AliasedInterface
     /**
      * @param string $globalId
      * @return string
-     * @throws \Doctrine\ORM\NonUniqueResultException
      */
     public function deleteVehicle(string $globalId): string
     {
         $id = AppGlobalId::getIdFromGlobalId($globalId);
 
         if (!$vehicle = $this->vehicleRepository->find($id)) {
-            throw new UserError(sprintf('Vehicle [%s] not found', $globalId));
+            throw new UserError(sprintf(
+                '%s [%s] not found',
+                AppGlobalId::getTypeFromGlobalId($globalId) ,
+                $globalId
+            ));
         }
 
         $this->vehicleRepository->delete($vehicle);

--- a/src/Vehicle/Domain/Car.php
+++ b/src/Vehicle/Domain/Car.php
@@ -2,34 +2,10 @@
 
 namespace App\Vehicle\Domain;
 
-class Car extends VehicleAbstract
+use App\Vehicle\Domain\Input\CarInput;
+
+class Car extends CarInput
 {
-    /**
-     * @var int
-     */
-    private $seatsNumber;
-
-    /**
-     * @param string $id
-     * @param string $manufacturer
-     * @param string $model
-     * @param int $seatsNumber
-     */
-    public function __construct(string $id, string $manufacturer, string $model, int $seatsNumber)
-    {
-        parent::__construct($id, $manufacturer, $model);
-
-        $this->seatsNumber = $seatsNumber;
-    }
-
-    /**
-     * @return int
-     */
-    public function getSeatsNumber(): int
-    {
-        return $this->seatsNumber;
-    }
-
     /**
      * @param int $seatsNumber
      * @return Car

--- a/src/Vehicle/Domain/Input/CarInput.php
+++ b/src/Vehicle/Domain/Input/CarInput.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Vehicle\Domain\Input;
+
+use App\Vehicle\Domain\VehicleAbstract;
+
+class CarInput extends VehicleAbstract
+{
+    /**
+     * @var string
+     */
+    protected $id;
+
+    /**
+     * @var int
+     */
+    protected $seatsNumber;
+
+    /**
+     * @param string $id
+     * @param string $manufacturer
+     * @param string $model
+     * @param int $seatsNumber
+     */
+    public function __construct(string $id, string $manufacturer, string $model, int $seatsNumber)
+    {
+        parent::__construct($id, $manufacturer, $model);
+
+        $this->seatsNumber = $seatsNumber;
+    }
+
+    /**
+     * @return int
+     */
+    public function getSeatsNumber(): int
+    {
+        return $this->seatsNumber;
+    }
+}

--- a/src/Vehicle/Domain/Input/TruckInput.php
+++ b/src/Vehicle/Domain/Input/TruckInput.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Vehicle\Domain\Input;
+
+use App\Vehicle\Domain\VehicleAbstract;
+
+class TruckInput extends VehicleAbstract
+{
+    /**
+     * @var string
+     */
+    protected $id;
+
+    /**
+     * @var int
+     */
+    protected $maximumLoad;
+
+    /**
+     * @param string $id
+     * @param string $manufacturer
+     * @param string $model
+     * @param int $maximumLoad
+     */
+    public function __construct(string $id, string $manufacturer, string $model, int $maximumLoad)
+    {
+        parent::__construct($id, $manufacturer, $model);
+
+        $this->maximumLoad = $maximumLoad;
+    }
+
+    /**
+     * @return int
+     */
+    public function getMaximumLoad(): int
+    {
+        return $this->maximumLoad;
+    }
+}

--- a/src/Vehicle/Domain/Truck.php
+++ b/src/Vehicle/Domain/Truck.php
@@ -2,34 +2,10 @@
 
 namespace App\Vehicle\Domain;
 
-class Truck extends VehicleAbstract
+use App\Vehicle\Domain\Input\TruckInput;
+
+class Truck extends TruckInput
 {
-    /**
-     * @var int
-     */
-    private $maximumLoad;
-
-    /**
-     * @param string $id
-     * @param string $manufacturer
-     * @param string $model
-     * @param int $maximumLoad
-     */
-    public function __construct(string $id, string $manufacturer, string $model, int $maximumLoad)
-    {
-        parent::__construct($id, $manufacturer, $model);
-
-        $this->maximumLoad = $maximumLoad;
-    }
-
-    /**
-     * @return int
-     */
-    public function getMaximumLoad(): int
-    {
-        return $this->maximumLoad;
-    }
-
     /**
      * @param int $maximumLoad
      * @return Truck

--- a/src/Vehicle/Domain/VehicleAbstract.php
+++ b/src/Vehicle/Domain/VehicleAbstract.php
@@ -7,17 +7,17 @@ abstract class VehicleAbstract implements VehicleInterface
     /**
      * @var string
      */
-    private $id;
+    protected $id;
 
     /**
      * @var string
      */
-    private $manufacturer;
+    protected $manufacturer;
 
     /**
      * @var string
      */
-    private $model;
+    protected $model;
 
     /**
      * @param string $id

--- a/tests/features/bootstrap/resources/graphql_query/car_update_invalid.graphql
+++ b/tests/features/bootstrap/resources/graphql_query/car_update_invalid.graphql
@@ -1,0 +1,8 @@
+mutation {
+    UpdateCar(input: {id: "Q2FyOmJhdG1vYmlsZQ==", manufacturer: "Wayne Corporation", model: "Batmobile", seats_number: 1}) {
+        id
+        manufacturer
+        model
+        seats_number
+    }
+}

--- a/tests/features/bootstrap/resources/graphql_query/truck_update_invalid.graphql
+++ b/tests/features/bootstrap/resources/graphql_query/truck_update_invalid.graphql
@@ -1,0 +1,8 @@
+mutation {
+    UpdateTruck(input: {id: "VHJ1Y2s6T3B0aW11cyBQcmltZQ==", manufacturer: "Transformer", model: "Optimus Prime", maximum_load: 5000}) {
+        id
+        manufacturer
+        model
+        maximum_load
+    }
+}

--- a/tests/features/queries/car.feature
+++ b/tests/features/queries/car.feature
@@ -10,16 +10,21 @@ Feature: Test car queries
     And the json response must be equals to car_create json response
     # Trying to create a duplicate of the previous car using the same ID
     When I submit the query car_create
-    Then The json element at "[errors][0][message]" should be equal to "Car [Q2FyOnRpbWU=] already exist"
+    Then The json element at "[errors][0][fields][0][message]" should be equal to "Car [Q2FyOnRpbWU=] already exist"
     When I submit the query car_update
     And the json response must be equals to car_update json response
     When I submit the query car_delete
     And the json response must be equals to car_delete json response
     # Trying to delete an already deleted car using its ID
     When I submit the query car_delete
-    Then The json element at "[errors][0][message]" should be equal to "Vehicle [Q2FyOnRpbWU=] not found"
+    Then The json element at "[errors][0][message]" should be equal to "Car [Q2FyOnRpbWU=] not found"
 
-  Scenario: Invalid car mutation
+  Scenario: Invalid car mutation creation
     When I submit the query car_create_invalid
-    Then The json element at "[errors][0][fields][0][field]" should be equal to "manufacturer"
+    Then The json element at "[errors][0][fields][0][name]" should be equal to "manufacturer"
     Then The json element at "[errors][0][fields][0][message]" should be equal to "This value is too short. It should have 2 characters or more."
+
+  Scenario: Trying to update a none existing car
+    When I submit the query car_update_invalid
+    Then The json element at "[errors][0][fields][0][name]" should be equal to "id"
+    Then The json element at "[errors][0][fields][0][message]" should be equal to "Car [Q2FyOmJhdG1vYmlsZQ==] not found"

--- a/tests/features/queries/truck.feature
+++ b/tests/features/queries/truck.feature
@@ -10,16 +10,20 @@ Feature: Test truck queries
     And the json response must be equals to truck_create json response
     # Trying to create a duplicate of the previous truck using the same ID
     When I submit the query truck_create
-    Then The json element at "[errors][0][message]" should be equal to "Truck [VHJ1Y2s6c3BlZWQ=] already exist"
+    Then The json element at "[errors][0][fields][0][message]" should be equal to "Truck [VHJ1Y2s6c3BlZWQ=] already exist"
     When I submit the query truck_update
     And the json response must be equals to truck_update json response
     When I submit the query truck_delete
     And the json response must be equals to truck_delete json response
     # Trying to delete an already deleted truck using its ID
     When I submit the query truck_delete
-    Then The json element at "[errors][0][message]" should be equal to "Vehicle [VHJ1Y2s6c3BlZWQ=] not found"
+    Then The json element at "[errors][0][message]" should be equal to "Truck [VHJ1Y2s6c3BlZWQ=] not found"
 
   Scenario: Invalid truck mutation
     When I submit the query truck_create_invalid
-    Then The json element at "[errors][0][fields][0][field]" should be equal to "model"
+    Then The json element at "[errors][0][fields][0][name]" should be equal to "model"
     Then The json element at "[errors][0][fields][0][message]" should be equal to "This value should not be blank."
+
+  Scenario: Trying to update a none existing truck
+    When I submit the query truck_update_invalid
+    Then The json element at "[errors][0][fields][0][message]" should be equal to "Truck [VHJ1Y2s6T3B0aW11cyBQcmltZQ==] not found"


### PR DESCRIPTION
- Use input objects to increase security.  
- Replace manual check by validators.
- Increase validation usage.
- Update readme.